### PR TITLE
Swagger UI + static files

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings.py
@@ -287,4 +287,10 @@ SPECTACULAR_SETTINGS = {
     'DESCRIPTION': ('An awesome Django backend for '
                     "'{{cookiecutter.project_name}}' project"),
     'VERSION': '0.1.0',
+    'SWAGGER_UI_SETTINGS': {
+        'deepLinking': True,
+        'persistAuthorization': True,
+        'displayOperationId': True,
+    },
+    'SWAGGER_UI_DIST': '//unpkg.com/swagger-ui-dist',
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
@@ -9,6 +9,11 @@ from django.urls import (
     include,
     path
 )
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularSwaggerView
+)
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -16,6 +21,11 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
+    urlpatterns.extend([
+        path('schema/', SpectacularAPIView.as_view(), name='schema'),
+        path('swagger/', SpectacularSwaggerView.as_view(), name='swagger'),
+    ])
+
     for el in [
         static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
         static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
@@ -5,9 +5,18 @@ For more information on this file, see
 https://docs.djangoproject.com/en/3.2/topics/http/urls/
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import (
+    include,
+    path
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('accounts.urls')),
 ]
+
+if settings.DEBUG:
+    for el in [
+        static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
+        static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    ]: urlpatterns += el  # noqa: E701


### PR DESCRIPTION
On debug instances only:
- Enable swagger for previewing schema and API endpoints.
- Save and serve static/media files on local filesystem, without using S3 backend.